### PR TITLE
Remove MyLNF fields from AudioProcessors.

### DIFF
--- a/src/ChowPhaserPlugin.cpp
+++ b/src/ChowPhaserPlugin.cpp
@@ -6,7 +6,6 @@
 
 ChowPhaser::ChowPhaser() : phaser (magicState)
 {
-    LookAndFeel::setDefaultLookAndFeel (&myLNF);
 }
 
 void ChowPhaser::addParameters (Parameters& params)

--- a/src/ChowPhaserPlugin.h
+++ b/src/ChowPhaserPlugin.h
@@ -25,8 +25,6 @@ private:
     AudioBuffer<float> monoBuffer;
     AudioBuffer<float> noModBuffer;
 
-    MyLNF myLNF;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ChowPhaser)
 };
 

--- a/src/ChowPhaserStereo.cpp
+++ b/src/ChowPhaserStereo.cpp
@@ -8,8 +8,6 @@ ChowPhaserStereo::ChowPhaserStereo()
 {
     phasers[0] = std::make_unique<SingleChannelPhaser> (magicState, "left_");
     phasers[1] = std::make_unique<SingleChannelPhaser> (magicState, "right_");
-
-    LookAndFeel::setDefaultLookAndFeel (&myLNF);
 }
 
 void ChowPhaserStereo::addParameters (Parameters& params)

--- a/src/ChowPhaserStereo.h
+++ b/src/ChowPhaserStereo.h
@@ -23,8 +23,6 @@ private:
     std::unique_ptr<SingleChannelPhaser> phasers[2];
     AudioBuffer<float> noModBuffer;
 
-    MyLNF myLNF;
-
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ChowPhaserStereo)
 };
 


### PR DESCRIPTION
This fixes https://github.com/jatinchowdhury18/ChowPhaser/issues/16.

`AudioProcessor`s should be instantiable from outside GUI thread, but these
`MyLNF` fields make it impossible because of RAII and `MyLNF` constructor
involves `Drawable::createFromImageData()`.